### PR TITLE
Add identity-provider endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0]
+
+### Added
+- `mcc.identityProvider.edit(attr)` -- configure Mailcow's external
+  Identity Provider (Keycloak, LDAP, or generic OIDC). Wraps the
+  `edit/identity-provider` route added in Mailcow's Moo 2025 update.
+- Discriminated-union types on `authsource` so TypeScript enforces the
+  right combination of fields per provider:
+  `KeycloakIdentityProviderAttributes`, `LdapIdentityProviderAttributes`,
+  `GenericOidcIdentityProviderAttributes`, and the union
+  `IdentityProviderAttributes`.
+- Unit tests covering each of the three authsource shapes against
+  mocked axios.
+
+Closes [#38](https://github.com/JustSamuel/ts-mailcow-api/issues/38).
+
 ## [1.4.0]
 
 ### Added
@@ -101,6 +117,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add status endpoints.
 - Move `/api/v1` out of the client into the user-supplied base URL.
 
+[1.5.0]: https://github.com/JustSamuel/ts-mailcow-api/releases/tag/v1.5.0
 [1.4.0]: https://github.com/JustSamuel/ts-mailcow-api/releases/tag/v1.4.0
 [1.3.0]: https://github.com/JustSamuel/ts-mailcow-api/releases/tag/v1.3.0
 [1.2.0]: https://github.com/JustSamuel/ts-mailcow-api/releases/tag/v1.2.0

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ at a typed interface documented in the
 | `domains`          | Domains                           |
 | `fail2Ban`         | Fail2Ban configuration            |
 | `forwardingHosts`  | Forwarding hosts                  |
+| `identityProvider` | External IdP (Keycloak/LDAP/OIDC) |
 | `logs`             | ACME, API, dovecot, postfix, ...  |
 | `mailbox`          | Mailboxes (and ACL, pushover, ...)|
 | `oauth2`           | OAuth2 clients                    |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-mailcow-api",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "TypeScript wrapper for the mailcow API.",
   "scripts": {
     "test": "ts-mocha \"test/**/*.test.ts\"",

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,6 +24,7 @@ import { TlsPolicyMapEndpoints, tlsPolicyMapEndpoints } from './endpoints/tls-po
 import { dkimEndpoints, DkimEndpoints } from './endpoints/dkim-endpoints';
 import { DomainAdminEndpoints, domainAdminEndpoints } from './endpoints/domain-admin-endpoints';
 import { RoutingEndpoints, routingEndpoints } from './endpoints/routing-endpoints';
+import { IdentityProviderEndpoints, identityProviderEndpoints } from './endpoints/identity-provider-endpoints';
 
 /**
  * Class containing all the logic to interface with the Mailcow API in TypeScript.
@@ -212,6 +213,14 @@ class MailcowClient {
    * @external
    */
   public routing: RoutingEndpoints = routingEndpoints(this);
+
+  /**
+   * Endpoint for configuring the external Identity Provider (Keycloak,
+   * LDAP, or a generic OIDC provider).
+   * See {@link IdentityProviderEndpoints}
+   * @external
+   */
+  public identityProvider: IdentityProviderEndpoints = identityProviderEndpoints(this);
 }
 
 export default MailcowClient;

--- a/src/endpoints/identity-provider-endpoints.ts
+++ b/src/endpoints/identity-provider-endpoints.ts
@@ -1,0 +1,42 @@
+import MailcowClient from '../index';
+import { IdentityProviderAttributes, IdentityProviderEditRequest, MailcowResponse } from '../types';
+
+/**
+ * Interface for the external Identity Provider endpoint.
+ *
+ * Mailcow has a single global identity-provider configuration -- there
+ * is no add or delete, only edit -- so this group exposes a single
+ * method.
+ */
+export interface IdentityProviderEndpoints {
+  /**
+   * Configure (or reconfigure) the external Identity Provider used for
+   * Mailcow login. Pass the attributes for one of the supported
+   * `authsource` values; the wrapper supplies the required
+   * `items: ['identity-provider']` envelope.
+   *
+   * @param attr - The identity-provider attributes to apply.
+   */
+  edit(attr: IdentityProviderAttributes): Promise<MailcowResponse>;
+}
+
+const IDENTITY_PROVIDER_ENDPOINTS = {
+  EDIT: 'edit/identity-provider',
+};
+
+/**
+ * Binder function between the MailcowClient class and the
+ * IdentityProviderEndpoints.
+ * @param bind - The MailcowClient to bind.
+ * @internal
+ */
+export function identityProviderEndpoints(bind: MailcowClient): IdentityProviderEndpoints {
+  return {
+    edit(attr: IdentityProviderAttributes): Promise<MailcowResponse> {
+      return bind.requestFactory.post<MailcowResponse, IdentityProviderEditRequest>(IDENTITY_PROVIDER_ENDPOINTS.EDIT, {
+        attr,
+        items: ['identity-provider'],
+      });
+    },
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2451,6 +2451,223 @@ export interface TransportMap {
 }
 
 /**
+ * Identity Provider authentication source.
+ *
+ * Mailcow's external authentication backends. `mailcow` (the built-in
+ * local password database) is not configurable via this endpoint and is
+ * therefore not part of this union.
+ */
+export type IdentityProviderAuthsource = 'ldap' | 'keycloak' | 'generic-oidc';
+
+/**
+ * Attributes shared across every identity-provider configuration,
+ * regardless of which auth source it targets.
+ */
+export interface BaseIdentityProviderAttributes {
+  /**
+   * If no matching attribute mapping exists for a user, the default template
+   * is used when creating the mailbox (not on update). Mailcow expects the
+   * template name as configured under "Mailbox templates".
+   */
+  default_template?: string;
+  /**
+   * Attribute values used to match a mailbox template. Each element pairs
+   * positionally with `templates` -- the n-th `mappers` entry selects the
+   * n-th `templates` entry.
+   */
+  mappers?: string[];
+  /**
+   * Mailbox template names. See `mappers` for how the two arrays are
+   * correlated.
+   */
+  templates?: string[];
+  /**
+   * Skip TLS certificate validation when contacting the auth source.
+   * @defaultValue false
+   */
+  ignore_ssl_error?: boolean;
+  /**
+   * Whether Mailcow should periodically pull every user from the auth
+   * source. Defaults to `false`; combine with `sync_interval` and
+   * `import_users` to enable scheduled syncs.
+   * @defaultValue false
+   */
+  periodic_sync?: boolean;
+  /**
+   * Whether new users discovered during a sync should be imported into
+   * Mailcow as mailboxes.
+   * @defaultValue false
+   */
+  import_users?: boolean;
+  /**
+   * Interval, in minutes, between periodic syncs.
+   * @defaultValue 15
+   */
+  sync_interval?: number;
+}
+
+/**
+ * Identity provider attributes for an external Keycloak server.
+ */
+export interface KeycloakIdentityProviderAttributes extends BaseIdentityProviderAttributes {
+  authsource: 'keycloak';
+  /**
+   * Base URL of the Keycloak server (no trailing slash needed).
+   */
+  server_url: string;
+  /**
+   * Keycloak realm where the Mailcow client is configured.
+   */
+  realm: string;
+  /**
+   * Client ID of the Mailcow OIDC client inside the realm.
+   */
+  client_id: string;
+  /**
+   * Client secret paired with `client_id`. Sent back from Mailcow as
+   * `"*"` once configured.
+   */
+  client_secret: string;
+  /**
+   * Primary redirect URL configured for the Mailcow client in Keycloak.
+   */
+  redirect_url: string;
+  /**
+   * Additional accepted redirect URLs.
+   */
+  redirect_url_extra?: string[];
+  /**
+   * Keycloak version (for example `26.1.3`). Mailcow uses this to pick
+   * the right admin API shape internally.
+   */
+  version: string;
+  /**
+   * Validate user passwords via the Keycloak admin REST API instead of
+   * relying only on the Authorization Code Flow. Required for IMAP/SMTP
+   * to keep working when Keycloak is the source of truth for passwords.
+   * @defaultValue false
+   */
+  mailpassword_flow?: boolean;
+}
+
+/**
+ * Identity provider attributes for an external LDAP / Active Directory
+ * server.
+ */
+export interface LdapIdentityProviderAttributes extends BaseIdentityProviderAttributes {
+  authsource: 'ldap';
+  /**
+   * Hostname (or comma-separated list of hostnames for fallback) of the
+   * LDAP server.
+   */
+  host: string;
+  /**
+   * LDAP port as a string.
+   */
+  port: string;
+  /**
+   * Use LDAPS. If `port` is 389 it is forced to 636.
+   * @defaultValue false
+   */
+  use_ssl?: boolean;
+  /**
+   * Use StartTLS. Mutually exclusive with `use_ssl`; preferred over SSL.
+   * @defaultValue false
+   */
+  use_tls?: boolean;
+  /**
+   * Base DN under which user searches are performed.
+   */
+  basedn: string;
+  /**
+   * LDAP attribute used to identify users at login.
+   * @defaultValue 'mail'
+   */
+  username_field?: string;
+  /**
+   * Optional LDAP search filter to limit who may authenticate.
+   */
+  filter?: string;
+  /**
+   * LDAP attribute whose value Mailcow maps to a mailbox template via
+   * `mappers` / `templates`.
+   */
+  attribute_field: string;
+  /**
+   * Bind DN used to perform user searches.
+   */
+  binddn: string;
+  /**
+   * Password for `binddn`.
+   */
+  bindpass: string;
+}
+
+/**
+ * Identity provider attributes for an arbitrary OIDC provider that is
+ * not Keycloak (Authentik, Auth0, Okta, ...).
+ */
+export interface GenericOidcIdentityProviderAttributes extends BaseIdentityProviderAttributes {
+  authsource: 'generic-oidc';
+  /**
+   * Authorization endpoint URL.
+   */
+  authorize_url: string;
+  /**
+   * Token endpoint URL.
+   */
+  token_url: string;
+  /**
+   * Userinfo endpoint URL.
+   */
+  userinfo_url: string;
+  /**
+   * Client ID issued by the OIDC provider.
+   */
+  client_id: string;
+  /**
+   * Client secret issued by the OIDC provider.
+   */
+  client_secret: string;
+  /**
+   * Primary redirect URL registered with the provider.
+   */
+  redirect_url: string;
+  /**
+   * Additional accepted redirect URLs.
+   */
+  redirect_url_extra?: string[];
+  /**
+   * Space-separated list of OIDC scopes requested at login.
+   * @defaultValue 'openid profile email mailcow_template'
+   */
+  client_scopes?: string;
+}
+
+/**
+ * Discriminated union of every supported identity-provider
+ * configuration. The `authsource` field is the discriminant.
+ */
+export type IdentityProviderAttributes =
+  | KeycloakIdentityProviderAttributes
+  | LdapIdentityProviderAttributes
+  | GenericOidcIdentityProviderAttributes;
+
+/**
+ * Wire-level body of the `edit/identity-provider` request. The wrapper
+ * builds this for you from {@link IdentityProviderAttributes}, but it
+ * is exported in case callers need to construct it manually.
+ *
+ * `items` is always `['identity-provider']` -- the array type is used
+ * (rather than a fixed tuple) so callers do not have to use a `const`
+ * assertion to satisfy this interface.
+ */
+export interface IdentityProviderEditRequest {
+  attr: IdentityProviderAttributes;
+  items: 'identity-provider'[];
+}
+
+/**
  * Interface for a general Mailcow API response.
  *
  * This is used when the API call doesn't return any objects, i.e. POST requests.

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -101,4 +101,72 @@ describe('Endpoints (smoke against mocked axios)', () => {
       restore();
     }
   });
+
+  describe('identityProvider.edit', () => {
+    it('posts to edit/identity-provider with the items envelope', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: 'object_modified' }]);
+      try {
+        await mcc.identityProvider.edit({
+          authsource: 'keycloak',
+          server_url: 'https://auth.example.test',
+          realm: 'mailcow',
+          client_id: 'mailcow_client',
+          client_secret: 'shh',
+          redirect_url: 'https://mail.example.test',
+          version: '26.1.3',
+        });
+        expect(captured.url).to.equal('https://example.test/api/v1/edit/identity-provider');
+        expect(captured.payload).to.deep.include({ items: ['identity-provider'] });
+        expect((captured.payload as any).attr).to.deep.include({
+          authsource: 'keycloak',
+          realm: 'mailcow',
+        });
+      } finally {
+        restore();
+      }
+    });
+
+    it('forwards LDAP attributes verbatim', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: 'object_modified' }]);
+      try {
+        await mcc.identityProvider.edit({
+          authsource: 'ldap',
+          host: '127.0.0.1',
+          port: '389',
+          basedn: 'DC=mailcow,DC=local',
+          attribute_field: 'othermailbox',
+          binddn: 'CN=LDAP,DC=mailcow,DC=local',
+          bindpass: 'pw',
+          filter: '(memberOf=DC=mailcow,DC=local)',
+        });
+        expect((captured.payload as any).attr.host).to.equal('127.0.0.1');
+        expect((captured.payload as any).attr.filter).to.equal('(memberOf=DC=mailcow,DC=local)');
+      } finally {
+        restore();
+      }
+    });
+
+    it('forwards generic-oidc attributes verbatim', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: 'object_modified' }]);
+      try {
+        await mcc.identityProvider.edit({
+          authsource: 'generic-oidc',
+          authorize_url: 'https://auth.example.test/authorize',
+          token_url: 'https://auth.example.test/token',
+          userinfo_url: 'https://auth.example.test/userinfo',
+          client_id: 'mailcow_client',
+          client_secret: 'shh',
+          redirect_url: 'https://mail.example.test',
+          client_scopes: 'openid profile email',
+        });
+        expect((captured.payload as any).attr.authsource).to.equal('generic-oidc');
+        expect((captured.payload as any).attr.client_scopes).to.equal('openid profile email');
+      } finally {
+        restore();
+      }
+    });
+  });
 });


### PR DESCRIPTION
Closes #38.

Wraps Mailcow's \`edit/identity-provider\` route (added in the Moo 2025 update). It's a single global config endpoint -- no add or delete, only edit -- so the wrapper exposes one method:

\`\`\`ts
await mcc.identityProvider.edit({
  authsource: 'keycloak',
  server_url: 'https://auth.example.test',
  realm: 'mailcow',
  client_id: 'mailcow_client',
  client_secret: 'shh',
  redirect_url: 'https://mail.example.test',
  version: '26.1.3',
  // optional shared fields:
  default_template: 'Default',
  periodic_sync: true,
  import_users: true,
  sync_interval: 30,
});
\`\`\`

The \`attr\` argument is a discriminated union on \`authsource\` so TypeScript enforces the right field combinations for each provider:

- \`KeycloakIdentityProviderAttributes\` -- \`authsource: 'keycloak'\` (server_url, realm, version, mailpassword_flow, ...)
- \`LdapIdentityProviderAttributes\` -- \`authsource: 'ldap'\` (host, port, basedn, binddn, bindpass, ...)
- \`GenericOidcIdentityProviderAttributes\` -- \`authsource: 'generic-oidc'\` (authorize_url, token_url, userinfo_url, client_scopes, ...)

\`BaseIdentityProviderAttributes\` carries the fields shared across all three (default_template, mappers, templates, ignore_ssl_error, periodic_sync, import_users, sync_interval).

The wrapper supplies the required \`items: ['identity-provider']\` envelope automatically; callers only deal with the attributes object.

## What this PR does not change

- Mailbox \`authsource\` is already typed correctly (added in 1.2.0) -- no change there.
- There is no \`get/identity-provider\` in the upstream spec, so the wrapper only exposes \`edit\`.

## Test plan

- [x] \`yarn build\`
- [x] \`yarn lint\`
- [x] \`yarn format\`
- [x] \`yarn test\` -- 19 passing (was 16), 70 pending (smoke skipped). Three new tests cover the route + items envelope for keycloak, and that LDAP / generic-oidc attributes pass through verbatim.
- [ ] Not exercised against a real Mailcow IdP in this PR; the route is documented as taking the exact shape the wrapper sends.

## Versioning

1.4.0 -> 1.5.0. Additive feature, no breaking changes.