### PR TITLE
Add quarantine.edit endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0]
+
+### Added
+- `mcc.quarantine.edit(payload)` -- act on quarantined messages. Wraps
+  `edit/qitem`. Supports the two actions Mailcow documents: `release`
+  (deliver to the recipient's inbox) and `learnham` (feed back to
+  Rspamd as a false positive). Previously the wrapper could only list
+  and delete quarantined items.
+- `QuarantineItemAction` and `EditQuarantineItemRequest` types.
+
+Closes [#47](https://github.com/JustSamuel/ts-mailcow-api/issues/47).
+
 ## [1.5.0]
 
 ### Added
@@ -117,6 +129,7 @@ Closes [#38](https://github.com/JustSamuel/ts-mailcow-api/issues/38).
 - Add status endpoints.
 - Move `/api/v1` out of the client into the user-supplied base URL.
 
+[1.6.0]: https://github.com/JustSamuel/ts-mailcow-api/releases/tag/v1.6.0
 [1.5.0]: https://github.com/JustSamuel/ts-mailcow-api/releases/tag/v1.5.0
 [1.4.0]: https://github.com/JustSamuel/ts-mailcow-api/releases/tag/v1.4.0
 [1.3.0]: https://github.com/JustSamuel/ts-mailcow-api/releases/tag/v1.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-mailcow-api",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "TypeScript wrapper for the mailcow API.",
   "scripts": {
     "test": "ts-mocha \"test/**/*.test.ts\"",

--- a/src/endpoints/quarantine-endpoints.ts
+++ b/src/endpoints/quarantine-endpoints.ts
@@ -1,4 +1,4 @@
-import { DeleteQuarantineRequest, MailcowResponse, QuarantineItem } from '../types';
+import { DeleteQuarantineRequest, EditQuarantineItemRequest, MailcowResponse, QuarantineItem } from '../types';
 import MailcowClient from '../index';
 
 /**
@@ -13,6 +13,14 @@ export interface QuarantineEndpoints {
   delete(payload: DeleteQuarantineRequest): Promise<MailcowResponse>;
 
   /**
+   * Acts on quarantined emails: release them to the recipient's inbox
+   * or learn them as ham to improve future Rspamd filtering.
+   * @param payload - The IDs to act on and the action to take.
+   * @returns A promise that resolves to the Mailcow API response indicating success or failure.
+   */
+  edit(payload: EditQuarantineItemRequest): Promise<MailcowResponse>;
+
+  /**
    * Retrieves all emails currently held in quarantine.
    * @returns A promise that resolves to an array of `QuarantineItem` representing each quarantined email.
    */
@@ -21,6 +29,7 @@ export interface QuarantineEndpoints {
 
 const QUARANTINE_ENDPOINTS = {
   DELETE: 'delete/qitem',
+  EDIT: 'edit/qitem',
   GET: 'get/quarantine/all',
 };
 
@@ -33,6 +42,9 @@ export function quarantineEndpoints(bind: MailcowClient): QuarantineEndpoints {
   return {
     delete(payload: DeleteQuarantineRequest): Promise<MailcowResponse> {
       return bind.requestFactory.post<MailcowResponse, number[]>(QUARANTINE_ENDPOINTS.DELETE, payload.items);
+    },
+    edit(payload: EditQuarantineItemRequest): Promise<MailcowResponse> {
+      return bind.requestFactory.post<MailcowResponse, EditQuarantineItemRequest>(QUARANTINE_ENDPOINTS.EDIT, payload);
     },
     get(): Promise<QuarantineItem[]> {
       return bind.requestFactory.get<QuarantineItem[]>(QUARANTINE_ENDPOINTS.GET);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1790,6 +1790,35 @@ export interface DeleteQuarantineRequest {
 }
 
 /**
+ * Action to take on a quarantined email via `edit/qitem`.
+ *
+ * - `release` -- deliver the email to the original recipient's inbox.
+ * - `learnham` -- mark the email as ham and feed it back to Rspamd as
+ *   a training sample. Useful for false positives.
+ *
+ * The quarantine queue is already presumed-spam by definition, so there
+ * is no `learnspam` counterpart -- Mailcow does not document one.
+ */
+export type QuarantineItemAction = 'release' | 'learnham';
+
+/**
+ * Request payload for `edit/qitem`.
+ *
+ * The `items` array holds the IDs of the quarantined messages to act
+ * on; the same `attr.action` is applied to every entry.
+ */
+export interface EditQuarantineItemRequest {
+  /**
+   * IDs of the quarantined messages to act on. Get them from
+   * `mcc.quarantine.get()`.
+   */
+  items: number[];
+  attr: {
+    action: QuarantineItemAction;
+  };
+}
+
+/**
  * Request payload to edit rate limits for specified domains.
  */
 export interface EditDomainRequest {

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -102,6 +102,31 @@ describe('Endpoints (smoke against mocked axios)', () => {
     }
   });
 
+  describe('quarantine.edit', () => {
+    it('posts to edit/qitem with the items + action payload', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['item_released', '33'] }]);
+      try {
+        await mcc.quarantine.edit({ items: [33, 34], attr: { action: 'release' } });
+        expect(captured.url).to.equal('https://example.test/api/v1/edit/qitem');
+        expect(captured.payload).to.deep.equal({ items: [33, 34], attr: { action: 'release' } });
+      } finally {
+        restore();
+      }
+    });
+
+    it('accepts learnham as an action', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['item_learned', '34'] }]);
+      try {
+        await mcc.quarantine.edit({ items: [34], attr: { action: 'learnham' } });
+        expect((captured.payload as any).attr.action).to.equal('learnham');
+      } finally {
+        restore();
+      }
+    });
+  });
+
   describe('identityProvider.edit', () => {
     it('posts to edit/identity-provider with the items envelope', async () => {
       const captured: Captured = {};


### PR DESCRIPTION
Closes #47.

Adds \`mcc.quarantine.edit(payload)\` -- wraps \`edit/qitem\` -- so callers can actually do something with quarantined messages instead of just listing and deleting them.

\`\`\`ts
// Release false positives to the recipient's inbox:
await mcc.quarantine.edit({ items: [33, 34], attr: { action: 'release' } });

// Or train them as ham so Rspamd stops catching them:
await mcc.quarantine.edit({ items: [34], attr: { action: 'learnham' } });
\`\`\`

The spec only documents two actions, \`release\` and \`learnham\`. The earlier issue body mentioned a \`learn_spam\` but Mailcow does not expose one -- the quarantine queue is presumed-spam by definition, so it would be redundant. I matched the documented surface.

## Test plan

- [x] \`yarn build\` (strict)
- [x] \`yarn lint\`
- [x] \`yarn format\`
- [x] \`yarn test\` -- 21 passing (was 19), 70 pending (smoke skipped). Two new tests cover the route, payload shape, and the learnham branch.
- [x] Not exercised against a real Mailcow instance in this PR; payload matches the spec example verbatim.

## Versioning

1.5.0 -> 1.6.0. Additive feature, no breaking changes.