### PR TITLE
Add time-limited alias endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea
 /.claude
+/.superpowers
 /dist
 node_modules
 docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0]
+
+### Added
+- `mcc.aliases.createTimeLimited(payload)` / `getTimeLimited(mailbox)` --
+  create and list Mailcow's time-limited (burner) aliases. Wraps
+  `add/time_limited_alias` and `get/time_limited_aliases/{mailbox}`.
+- `mcc.aliases.editTimeLimited(payload)` / `deleteTimeLimited(payload)` --
+  extend, make permanent, or remove a time-limited alias. Wraps
+  `edit/time_limited_alias` and `delete/time_limited_alias`, which exist
+  in the live API but aren't documented in the upstream spec.
+- `TimeLimitedAlias`, `TimeLimitedAliasPostRequest`,
+  `TimeLimitedAliasEditRequest`, and `TimeLimitedAliasDeleteRequest` types.
+
+Closes [#48](https://github.com/JustSamuel/ts-mailcow-api/issues/48).
+
 ## [1.6.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-mailcow-api",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "TypeScript wrapper for the mailcow API.",
   "scripts": {
     "test": "ts-mocha \"test/**/*.test.ts\"",

--- a/src/endpoints/alias-endpoints.ts
+++ b/src/endpoints/alias-endpoints.ts
@@ -1,4 +1,14 @@
-import { Alias, AliasDeleteRequest, AliasPostRequest, AliasEditRequest, MailcowResponse } from '../types';
+import {
+  Alias,
+  AliasDeleteRequest,
+  AliasPostRequest,
+  AliasEditRequest,
+  MailcowResponse,
+  TimeLimitedAlias,
+  TimeLimitedAliasDeleteRequest,
+  TimeLimitedAliasEditRequest,
+  TimeLimitedAliasPostRequest,
+} from '../types';
 import MailcowClient from '../index';
 import { wrapPromiseToArray } from '../request-factory';
 
@@ -29,6 +39,33 @@ export interface AliasEndpoints {
    * @param payload - The deletion payload.
    */
   delete(payload: AliasDeleteRequest): Promise<MailcowResponse>;
+
+  /**
+   * Endpoint for creating a time-limited (burner) alias. Mailcow always
+   * generates the address itself -- there is no way to request a specific
+   * one.
+   * @param payload - The creation payload.
+   */
+  createTimeLimited(payload: TimeLimitedAliasPostRequest): Promise<MailcowResponse>;
+
+  /**
+   * Endpoint for listing the active time-limited aliases for a mailbox.
+   * @param mailbox - The mailbox to list time-limited aliases for.
+   */
+  getTimeLimited(mailbox: string): Promise<TimeLimitedAlias[]>;
+
+  /**
+   * Endpoint for extending a time-limited alias's expiry, or marking it
+   * permanent.
+   * @param payload - The edit payload.
+   */
+  editTimeLimited(payload: TimeLimitedAliasEditRequest): Promise<MailcowResponse>;
+
+  /**
+   * Endpoint for deleting one or more time-limited aliases.
+   * @param payload - The deletion payload.
+   */
+  deleteTimeLimited(payload: TimeLimitedAliasDeleteRequest): Promise<MailcowResponse>;
 }
 
 const ALIAS_ENDPOINTS = {
@@ -36,6 +73,10 @@ const ALIAS_ENDPOINTS = {
   ADD: 'add/alias',
   EDIT: 'edit/alias',
   DELETE: 'delete/alias',
+  ADD_TIME_LIMITED: 'add/time_limited_alias',
+  GET_TIME_LIMITED: 'get/time_limited_aliases',
+  EDIT_TIME_LIMITED: 'edit/time_limited_alias',
+  DELETE_TIME_LIMITED: 'delete/time_limited_alias',
 };
 
 /**
@@ -56,6 +97,27 @@ export function aliasEndpoints(bind: MailcowClient): AliasEndpoints {
     },
     delete: (payload: AliasDeleteRequest): Promise<MailcowResponse> => {
       return bind.requestFactory.post<MailcowResponse, number[]>(ALIAS_ENDPOINTS.DELETE, payload.items);
+    },
+    createTimeLimited: (payload: TimeLimitedAliasPostRequest): Promise<MailcowResponse> => {
+      return bind.requestFactory.post<MailcowResponse, TimeLimitedAliasPostRequest>(
+        ALIAS_ENDPOINTS.ADD_TIME_LIMITED,
+        payload,
+      );
+    },
+    getTimeLimited(mailbox: string): Promise<TimeLimitedAlias[]> {
+      return bind.requestFactory.get<TimeLimitedAlias[]>(`${ALIAS_ENDPOINTS.GET_TIME_LIMITED}/${mailbox}`);
+    },
+    editTimeLimited: (payload: TimeLimitedAliasEditRequest): Promise<MailcowResponse> => {
+      return bind.requestFactory.post<MailcowResponse, TimeLimitedAliasEditRequest>(
+        ALIAS_ENDPOINTS.EDIT_TIME_LIMITED,
+        payload,
+      );
+    },
+    deleteTimeLimited: (payload: TimeLimitedAliasDeleteRequest): Promise<MailcowResponse> => {
+      return bind.requestFactory.post<MailcowResponse, TimeLimitedAliasDeleteRequest>(
+        ALIAS_ENDPOINTS.DELETE_TIME_LIMITED,
+        payload,
+      );
     },
   };
 }

--- a/src/endpoints/alias-endpoints.ts
+++ b/src/endpoints/alias-endpoints.ts
@@ -43,7 +43,8 @@ export interface AliasEndpoints {
   /**
    * Endpoint for creating a time-limited (burner) alias. Mailcow always
    * generates the address itself -- there is no way to request a specific
-   * one.
+   * one. The generated address is not returned; call `getTimeLimited` to
+   * retrieve it.
    * @param payload - The creation payload.
    */
   createTimeLimited(payload: TimeLimitedAliasPostRequest): Promise<MailcowResponse>;
@@ -56,7 +57,8 @@ export interface AliasEndpoints {
 
   /**
    * Endpoint for extending a time-limited alias's expiry, or marking it
-   * permanent.
+   * permanent. Mailcow silently no-ops if neither `validity` nor
+   * `permanent` is provided in the payload.
    * @param payload - The edit payload.
    */
   editTimeLimited(payload: TimeLimitedAliasEditRequest): Promise<MailcowResponse>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -744,6 +744,102 @@ export interface AliasDeleteRequest {
 }
 
 /**
+ * Request payload to create a time-limited (burner) alias. Mailcow always
+ * generates the address itself; there is no way to request a specific one.
+ */
+export interface TimeLimitedAliasPostRequest {
+  /**
+   * The domain to generate the alias under. Must be the mailbox's own
+   * domain or one of its alias domains.
+   */
+  domain: string;
+  /**
+   * The mailbox the alias should forward to. Defaults to the
+   * API-authenticated mailbox when omitted.
+   */
+  username?: string;
+  /**
+   * How many hours the alias stays valid, from 1 to 87600 (10 years).
+   * Defaults to 8760 (1 year). Ignored when `permanent` is true.
+   */
+  validity?: number;
+  /**
+   * If true, the alias never expires and `validity` is ignored.
+   */
+  permanent?: boolean;
+  /**
+   * Optional free-text description.
+   */
+  description?: string;
+}
+
+/**
+ * A time-limited (burner) alias as returned by Mailcow.
+ */
+export interface TimeLimitedAlias {
+  /**
+   * The generated alias address.
+   */
+  address: string;
+  /**
+   * The mailbox this alias forwards to.
+   */
+  goto: string;
+  /**
+   * Free-text description set at creation time.
+   */
+  description: string;
+  /**
+   * Unix timestamp after which the alias expires. Meaningless when
+   * `permanent` is `"1"`.
+   */
+  validity: number;
+  /**
+   * Creation timestamp.
+   */
+  created: string;
+  /**
+   * Last modified timestamp, or null if never modified.
+   */
+  modified: string | null;
+  /**
+   * String indicating whether the alias never expires ("1" for yes, "0"
+   * for no).
+   */
+  permanent: string;
+}
+
+/**
+ * Request payload to extend a time-limited alias's expiry, or mark it
+ * permanent.
+ */
+export interface TimeLimitedAliasEditRequest {
+  /**
+   * The address(es) to update.
+   */
+  address: string | string[];
+  /**
+   * New validity window in hours from now. Replaces the existing expiry
+   * rather than adding to it. Ignored when `permanent` is true.
+   */
+  validity?: number;
+  /**
+   * If true, marks the alias as never expiring.
+   */
+  permanent?: boolean;
+}
+
+/**
+ * Request payload to delete one or more time-limited aliases.
+ */
+export interface TimeLimitedAliasDeleteRequest {
+  /**
+   * The address(es) to delete.
+   */
+  address: string | string[];
+}
+
+/**
  * Interface of the Alias as returned by Mailcow.
  */
 export interface Alias extends AliasAttributes {

--- a/src/types.ts
+++ b/src/types.ts
@@ -811,7 +811,8 @@ export interface TimeLimitedAlias {
 
 /**
  * Request payload to extend a time-limited alias's expiry, or mark it
- * permanent.
+ * permanent. Note: Mailcow silently no-ops if neither `validity` nor
+ * `permanent` is provided.
  */
 export interface TimeLimitedAliasEditRequest {
   /**

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -194,4 +194,80 @@ describe('Endpoints (smoke against mocked axios)', () => {
       }
     });
   });
+
+  describe('aliases.createTimeLimited', () => {
+    it('posts to add/time_limited_alias with the payload', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['mailbox_modified', 'foo@example.test'] }]);
+      try {
+        await mcc.aliases.createTimeLimited({ domain: 'example.test', username: 'foo@example.test' });
+        expect(captured.url).to.equal('https://example.test/api/v1/add/time_limited_alias');
+        expect(captured.payload).to.deep.equal({ domain: 'example.test', username: 'foo@example.test' });
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('aliases.getTimeLimited', () => {
+    it('hits get/time_limited_aliases/{mailbox} and returns the array', async () => {
+      const captured: Captured = {};
+      const alias = {
+        address: 'abc.def@example.test',
+        goto: 'foo@example.test',
+        description: '',
+        validity: 1893456000,
+        created: '2026-01-01 00:00:00',
+        modified: null,
+        permanent: '0',
+      };
+      const restore = withMockedAxios(captured, [alias]);
+      try {
+        const res = await mcc.aliases.getTimeLimited('foo@example.test');
+        expect(captured.url).to.equal('https://example.test/api/v1/get/time_limited_aliases/foo@example.test');
+        expect(res).to.deep.equal([alias]);
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('aliases.editTimeLimited', () => {
+    it('posts to edit/time_limited_alias with address + validity', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['mailbox_modified', 'foo@example.test'] }]);
+      try {
+        await mcc.aliases.editTimeLimited({ address: 'abc.def@example.test', validity: 24 });
+        expect(captured.url).to.equal('https://example.test/api/v1/edit/time_limited_alias');
+        expect(captured.payload).to.deep.equal({ address: 'abc.def@example.test', validity: 24 });
+      } finally {
+        restore();
+      }
+    });
+
+    it('accepts permanent as an alternative to validity', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['mailbox_modified', 'foo@example.test'] }]);
+      try {
+        await mcc.aliases.editTimeLimited({ address: ['abc.def@example.test'], permanent: true });
+        expect((captured.payload as any).permanent).to.equal(true);
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('aliases.deleteTimeLimited', () => {
+    it('posts to delete/time_limited_alias with the address payload', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['mailbox_modified', 'foo@example.test'] }]);
+      try {
+        await mcc.aliases.deleteTimeLimited({ address: 'abc.def@example.test' });
+        expect(captured.url).to.equal('https://example.test/api/v1/delete/time_limited_alias');
+        expect(captured.payload).to.deep.equal({ address: 'abc.def@example.test' });
+      } finally {
+        restore();
+      }
+    });
+  });
 });

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -250,7 +250,7 @@ describe('Endpoints (smoke against mocked axios)', () => {
       const restore = withMockedAxios(captured, [{ type: 'success', msg: ['mailbox_modified', 'foo@example.test'] }]);
       try {
         await mcc.aliases.editTimeLimited({ address: ['abc.def@example.test'], permanent: true });
-        expect((captured.payload as any).permanent).to.equal(true);
+        expect(captured.payload).to.deep.equal({ address: ['abc.def@example.test'], permanent: true });
       } finally {
         restore();
       }


### PR DESCRIPTION
## Summary

Closes #48. Adds Mailcow's time-limited ("burner") alias feature to `AliasEndpoints`: `createTimeLimited`, `getTimeLimited`, `editTimeLimited`, `deleteTimeLimited`.

The issue asked for create + list only, matching the OpenAPI spec. I checked Mailcow's actual PHP handler (`functions.mailbox.inc.php`) instead of trusting the spec or the issue's proposed shape, and it's a good thing I did:

- The proposed create payload (`username` + optional `address`) doesn't match reality. Mailcow always generates the address server-side -- there's no way to request a specific one. The field it actually requires, `domain`, wasn't in the issue at all.
- `edit` and `delete` routes for time-limited aliases exist in the live API too, behind the same `spam_alias` ACL flag, just undocumented upstream. It's the same "spec lags the PHP API" gap `CLAUDE.md` already warns about elsewhere. I folded all four routes into this PR instead of splitting edit/delete off into a follow-up issue.

## Changes

- `TimeLimitedAlias`, `TimeLimitedAliasPostRequest`, `TimeLimitedAliasEditRequest`, `TimeLimitedAliasDeleteRequest` types in `src/types.ts`.
- Four new methods on `AliasEndpoints` in `src/endpoints/alias-endpoints.ts`, following the existing one-line delegate pattern.
- `TimeLimitedAlias.permanent` is typed `string` (`"1"`/`"0"`), matching `AppPassword.active`'s convention for an uncast DB fetch, rather than `Alias.active`'s `boolean` (whose handler explicitly casts it).
- 5 new unit tests against the mocked-axios harness.
- CHANGELOG entry and version bump to 1.7.0.

## Notes for review

- `editTimeLimited` silently no-ops server-side if you set neither `validity` nor `permanent`. I documented that in JSDoc on the type and the method rather than blocking it at the type level -- a discriminated union would work, but it'd fight anyone building payloads dynamically, and a wrapper shouldn't reject payloads the real API is happy to accept.
- `permanent` goes out as a JSON boolean; Mailcow's own UI sends `"1"`. The PHP paths I read use loose-truthiness checks, so this should be fine, but I haven't actually round-tripped it against a live server. `test:smoke` wasn't extended for this feature -- same as 1.5.0 and 1.6.0 before it.
- `reference/openapi.yaml` and `README.md` are untouched on purpose: the former's a frozen upstream snapshot, and the latter only lists endpoint groups, where `aliases` is already listed.

## Test plan

- [x] `yarn build` / `yarn lint` / `yarn format` / `yarn test` all pass (26/26).
- [ ] Live smoke test against demo.mailcow.email -- not run (`MAILCOW_E2E=1`). Flagging the `permanent` wire-format assumption above in case that's worth a manual check.
