### PR TITLE
Add force_tfa and expose sender_acl on mailboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0]
+
+### Added
+- `force_tfa` on `BaseMailboxAttributes` (optional), so `MailboxPostRequest`
+  and `MailboxEditAttributes` can set it. Mirrors Mailcow's
+  `add/mailbox` and `edit/mailbox` behaviour, which default it to `false`
+  when omitted.
+- `sender_acl` (top-level) and `force_tfa` (nested under `attributes`) on
+  the `Mailbox` response type, matching what `get/mailbox/{id}` and
+  `get/mailbox/all/{domain}` actually return. Note that `force_tfa` lives
+  under `attributes` rather than top-level as originally proposed in the
+  issue -- verified against Mailcow's PHP source, which stores and
+  returns it alongside `force_pw_update` and the other `attributes`
+  fields.
+
+Closes [#74](https://github.com/JustSamuel/ts-mailcow-api/issues/74).
+
 ## [1.7.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-mailcow-api",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "TypeScript wrapper for the mailcow API.",
   "scripts": {
     "test": "ts-mocha \"test/**/*.test.ts\"",

--- a/src/types.ts
+++ b/src/types.ts
@@ -308,6 +308,12 @@ export interface BaseMailboxAttributes {
    */
   force_pw_update: boolean;
   /**
+   * Boolean if the user is forced to enroll in two-factor authentication on
+   * login. Optional -- Mailcow falls back to its configured default
+   * (`false` out of the box) when omitted.
+   */
+  force_tfa?: boolean;
+  /**
    * The ull name of the mailbox user.
    */
   name: string;
@@ -452,6 +458,11 @@ export interface Mailbox {
      */
     force_pw_update: boolean;
     /**
+     * Boolean if the user is forced to enroll in two-factor authentication
+     * on login.
+     */
+    force_tfa: boolean;
+    /**
      * Boolean if inbound email encryption is forced.
      */
     tls_enforce_in: boolean;
@@ -553,6 +564,10 @@ export interface Mailbox {
    * Boolean if the mailbox is relayed.
    */
   is_relayed: boolean;
+  /**
+   * List of allowed send-from addresses for this mailbox.
+   */
+  sender_acl: string[];
 }
 
 /**

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -75,6 +75,99 @@ describe('Endpoints (smoke against mocked axios)', () => {
     }
   });
 
+  it('mailbox.create posts to add/mailbox with force_tfa included', async () => {
+    const captured: Captured = {};
+    const restore = withMockedAxios(captured, [{ type: 'success', msg: 'mailbox_added' }]);
+    try {
+      await mcc.mailbox.create({
+        domain: 'example.test',
+        local_part: 'info',
+        name: 'Full name',
+        active: 1,
+        force_pw_update: false,
+        force_tfa: true,
+        password: 'x',
+        password2: 'x',
+        quota: 1024,
+        authsource: 'mailcow',
+        tls_enforce_in: false,
+        tls_enforce_out: false,
+      });
+      expect(captured.url).to.equal('https://example.test/api/v1/add/mailbox');
+      expect(captured.payload).to.deep.include({ force_tfa: true });
+    } finally {
+      restore();
+    }
+  });
+
+  it('mailbox.edit posts to edit/mailbox with force_tfa and sender_acl in attr', async () => {
+    const captured: Captured = {};
+    const restore = withMockedAxios(captured, [{ type: 'success', msg: 'mailbox_modified' }]);
+    try {
+      await mcc.mailbox.edit({
+        items: ['info@example.test'],
+        attr: { force_tfa: true, sender_acl: ['@example.test'] },
+      });
+      expect(captured.url).to.equal('https://example.test/api/v1/edit/mailbox');
+      expect(captured.payload).to.deep.equal({
+        items: ['info@example.test'],
+        attr: { force_tfa: true, sender_acl: ['@example.test'] },
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('mailbox.get("one") surfaces force_tfa (nested under attributes) and sender_acl (top-level)', async () => {
+    const captured: Captured = {};
+    const mailboxResponse = {
+      username: 'one@example.test',
+      active: true,
+      active_int: 1,
+      domain: 'example.test',
+      name: 'One',
+      local_part: 'one',
+      quota: 1024,
+      messages: 0,
+      attributes: {
+        force_pw_update: false,
+        force_tfa: true,
+        tls_enforce_in: false,
+        tls_enforce_out: false,
+        sogo_access: true,
+        imap_access: true,
+        pop3_access: true,
+        smtp_access: true,
+        xmpp_access: false,
+        xmpp_admin: false,
+        mailbox_format: 'maildir:',
+        quarantine_notification: 'never' as const,
+        quarantine_category: 'reject' as const,
+      },
+      quota_used: 0,
+      percent_in_use: 0,
+      last_imap_login: 0,
+      last_smtp_login: 0,
+      last_pop3_login: 0,
+      percent_class: 'success' as const,
+      max_new_quota: 0,
+      spam_aliases: 0,
+      pushover_active: false,
+      rl: { value: 0, frame: 'h' as const },
+      rl_scope: 'domain',
+      is_relayed: false,
+      sender_acl: ['one@example.test'],
+    };
+    const restore = withMockedAxios(captured, mailboxResponse);
+    try {
+      const res = await mcc.mailbox.get('one@example.test');
+      expect(res[0].attributes.force_tfa).to.equal(true);
+      expect(res[0].sender_acl).to.deep.equal(['one@example.test']);
+    } finally {
+      restore();
+    }
+  });
+
   it('domains.create posts to add/domain with the given payload', async () => {
     const captured: Captured = {};
     const restore = withMockedAxios(captured, [{ type: 'success', msg: 'created' }]);


### PR DESCRIPTION
Adds `force_tfa` and `sender_acl` type coverage for mailboxes.

`force_tfa` is settable on both `add/mailbox` and `edit/mailbox` upstream, but was missing from `BaseMailboxAttributes`, so neither `MailboxPostRequest` nor `MailboxEditAttributes` could set it. I added it as `force_tfa?: boolean` rather than required -- making it required would break every existing caller of those two interfaces, and Mailcow's PHP source shows it has a real default (`$MAILBOX_DEFAULT_ATTRIBUTES['force_tfa'] = false`) rather than being always-required.

I checked the actual behavior in `data/web/inc/functions.mailbox.inc.php` in mailcow-dockerized instead of just going with the issue's proposed shape or the vendored openapi.yaml. The issue proposed putting `force_tfa` directly on the top-level `Mailbox` response type, matching the vendored spec's request-body schema. But the `mailbox_details` case in that PHP file builds the response with `$mailboxdata['attributes'] = json_decode($row['attributes'], true)`, and `force_tfa` lives inside that stored `attributes` JSON blob alongside `force_pw_update`, `tls_enforce_in`, `tls_enforce_out`, and `sogo_access`. So this PR nests `force_tfa` under `Mailbox.attributes` instead of adding it at the top level. `sender_acl` is different: the same PHP function sets `$mailboxdata['sender_acl']` directly, so the issue was right about that one -- it's added at the top level of `Mailbox`, typed `string[]`.

For how to type each field, I followed what's already there: sibling boolean fields on `Mailbox.attributes` (`force_pw_update`, `tls_enforce_in`, etc.) are all typed `boolean` even though the wire format is PHP's intval/string-cast handling, and the fields set in the same conditional block as `sender_acl` (`is_relayed`, `rl_scope`, `spam_aliases`) are all required rather than optional, so `sender_acl` follows suit.

Added three tests to `test/endpoints.test.ts`: `mailbox.create` and `mailbox.edit` carrying `force_tfa` (and `sender_acl` on edit) through to the request payload, plus a `mailbox.get` test asserting the response shape (`attributes.force_tfa` nested, `sender_acl` top-level). `yarn lint`, `yarn format`, `yarn build`, and `yarn test` all pass.

Closes #74.
