### PR TITLE
Add coverage for CORS, domain-admin ACL, tag deletion, and other low-priority endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0]
+
+### Added
+- `mcc.cors.edit(attr)` -- manage the API's Cross-Origin Resource Sharing
+  settings. Wraps `edit/cors`. New `src/endpoints/cors-endpoints.ts` file,
+  plus `CorsAttributes`, `CorsAllowedMethod`, and `CorsEditRequest` types.
+- `mcc.domainAdmins.editACL(payload)` -- edit a Domain Admin's ACL flags,
+  distinct from the mailbox-level `user-acl`. Wraps `edit/da-acl`. Adds
+  the `DaAclEditRequest` type; its `da_acl` flag list is sourced from the
+  live `da_acl` table schema rather than the OpenAPI spec's example,
+  which is missing the `mailbox_relayhost` and `domain_relayhost` flags.
+- `mcc.domains.deleteTag(domain, payload)` -- remove one or more tags
+  from a domain. Wraps `delete/domain/tag/{domain}`. Adds the
+  `DomainTagDeleteRequest` type.
+- `mcc.domains.editFooter(payload)` -- set a domain-wide mail footer
+  template. Wraps `edit/domain/footer`. Adds the `DomainFooterEditRequest`
+  type; its exclude list is named `exclude` (mixing mailbox addresses and
+  alias-domain names), not `mbox_exclude` as the OpenAPI spec documents --
+  the PHP handler sorts entries into `mbox_exclude`/`alias_domain_exclude`
+  itself.
+- `mcc.mailbox.deleteTag(mailbox, payload)` -- remove one or more tags
+  from a mailbox. Wraps `delete/mailbox/tag/{mailbox}`. Adds the
+  `MailboxTagDeleteRequest` type.
+- `mcc.mailbox.editCustomAttribute(payload)` -- write arbitrary custom
+  attributes on one or more mailboxes via parallel `attribute`/`value`
+  arrays. Wraps `edit/mailbox/custom-attribute`. Adds the
+  `MailboxCustomAttributeEditRequest` type.
+- `mcc.mailbox.getSpamScore(mailbox?)` -- read a mailbox's spam score
+  override, or the global default for admins when omitted. Wraps
+  `get/spam-score/{mailbox}`, the GET counterpart to the existing
+  `editSpamScore`. Adds the `SpamScoreGetResponse` type; its response key
+  is `score`, not `spam_score` as the OpenAPI spec documents.
+- `mcc.mailbox.getByDomain(domain)` -- list all mailboxes belonging to a
+  specific domain, avoiding the fetch-everything-and-filter pattern the
+  README previously showed. Wraps `get/mailbox/all/{domain}`.
+
+Closes [#49](https://github.com/JustSamuel/ts-mailcow-api/issues/49).
+
 ## [1.8.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-mailcow-api",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "TypeScript wrapper for the mailcow API.",
   "scripts": {
     "test": "ts-mocha \"test/**/*.test.ts\"",

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,7 @@ import { dkimEndpoints, DkimEndpoints } from './endpoints/dkim-endpoints';
 import { DomainAdminEndpoints, domainAdminEndpoints } from './endpoints/domain-admin-endpoints';
 import { RoutingEndpoints, routingEndpoints } from './endpoints/routing-endpoints';
 import { IdentityProviderEndpoints, identityProviderEndpoints } from './endpoints/identity-provider-endpoints';
+import { CorsEndpoints, corsEndpoints } from './endpoints/cors-endpoints';
 
 /**
  * Class containing all the logic to interface with the Mailcow API in TypeScript.
@@ -221,6 +222,13 @@ class MailcowClient {
    * @external
    */
   public identityProvider: IdentityProviderEndpoints = identityProviderEndpoints(this);
+
+  /**
+   * Endpoint for configuring the API's CORS settings.
+   * See {@link CorsEndpoints}
+   * @external
+   */
+  public cors: CorsEndpoints = corsEndpoints(this);
 }
 
 export default MailcowClient;

--- a/src/endpoints/cors-endpoints.ts
+++ b/src/endpoints/cors-endpoints.ts
@@ -1,0 +1,34 @@
+import MailcowClient from '../index';
+import { CorsAttributes, CorsEditRequest, MailcowResponse } from '../types';
+
+/**
+ * Interface for the API's Cross-Origin Resource Sharing (CORS) endpoint.
+ *
+ * CORS is a single global API setting, not tied to any resource -- there
+ * is no add or delete, only edit -- so this group exposes a single
+ * method.
+ */
+export interface CorsEndpoints {
+  /**
+   * Configure the API's CORS settings.
+   * @param attr - The CORS attributes to apply.
+   */
+  edit(attr: CorsAttributes): Promise<MailcowResponse>;
+}
+
+const CORS_ENDPOINTS = {
+  EDIT: 'edit/cors',
+};
+
+/**
+ * Binder function between the MailcowClient class and the CorsEndpoints.
+ * @param bind - The MailcowClient to bind.
+ * @internal
+ */
+export function corsEndpoints(bind: MailcowClient): CorsEndpoints {
+  return {
+    edit(attr: CorsAttributes): Promise<MailcowResponse> {
+      return bind.requestFactory.post<MailcowResponse, CorsEditRequest>(CORS_ENDPOINTS.EDIT, { attr });
+    },
+  };
+}

--- a/src/endpoints/domain-admin-endpoints.ts
+++ b/src/endpoints/domain-admin-endpoints.ts
@@ -1,5 +1,6 @@
 import {
   CreateDomainAdminRequest,
+  DaAclEditRequest,
   DeleteDomainAdminRequest,
   DomainAdmin,
   EditDomainAdminRequest,
@@ -45,12 +46,21 @@ export interface DomainAdminEndpoints {
    * @returns A promise that resolves to an array of `DomainAdmin` objects.
    */
   get(id: 'all'): Promise<DomainAdmin[]>;
+
+  /**
+   * Edits the ACL flags of a Domain Admin user. Distinct from the
+   * mailbox-level user ACL edited via `MailboxEndpoints.editUserACL`.
+   * @param payload - Object containing the username(s) and the ACL flags to set.
+   * @returns A promise that resolves to a response indicating success or failure.
+   */
+  editACL(payload: DaAclEditRequest): Promise<MailcowResponse>;
 }
 
 const DOMAIN_ADMIN_ENDPOINTS = {
   CREATE: 'add/domain-admin',
   ISSUE_SSO_TOKEN: 'add/sso/domain-admin',
   EDIT: 'edit/domain-admin',
+  EDIT_ACL: 'edit/da-acl',
   DELETE: 'delete/domain-admin',
   GET_ALL: 'get/domain-admin/all',
 };
@@ -82,6 +92,9 @@ export function domainAdminEndpoints(bind: MailcowClient): DomainAdminEndpoints 
     },
     get(): Promise<DomainAdmin[]> {
       return bind.requestFactory.get<DomainAdmin[]>(DOMAIN_ADMIN_ENDPOINTS.GET_ALL);
+    },
+    editACL(payload: DaAclEditRequest): Promise<MailcowResponse> {
+      return bind.requestFactory.post<MailcowResponse, DaAclEditRequest>(DOMAIN_ADMIN_ENDPOINTS.EDIT_ACL, payload);
     },
   };
 }

--- a/src/endpoints/domain-endpoints.ts
+++ b/src/endpoints/domain-endpoints.ts
@@ -1,4 +1,12 @@
-import { DomainDeleteRequest, DomainEditRequest, DomainPostRequest, Domain, MailcowResponse } from '../types';
+import {
+  DomainDeleteRequest,
+  DomainEditRequest,
+  DomainFooterEditRequest,
+  DomainPostRequest,
+  DomainTagDeleteRequest,
+  Domain,
+  MailcowResponse,
+} from '../types';
 import MailcowClient from '../index';
 import { wrapPromiseToArray } from '../request-factory';
 
@@ -29,13 +37,28 @@ export interface DomainEndpoints {
    * @param payload - The edit payload.
    */
   edit(payload: DomainEditRequest): Promise<MailcowResponse>;
+
+  /**
+   * Endpoint for removing one or more tags from a domain.
+   * @param domain - The domain to remove tags from.
+   * @param payload - The tags to remove.
+   */
+  deleteTag(domain: string, payload: DomainTagDeleteRequest): Promise<MailcowResponse>;
+
+  /**
+   * Endpoint for setting the domain-wide mail footer template.
+   * @param payload - The edit payload.
+   */
+  editFooter(payload: DomainFooterEditRequest): Promise<MailcowResponse>;
 }
 
 const DOMAIN_ENDPOINTS = {
   GET: 'get/domain',
   ADD: 'add/domain',
   DELETE: 'delete/domain',
+  DELETE_TAG: 'delete/domain/tag',
   EDIT: 'edit/domain',
+  EDIT_FOOTER: 'edit/domain/footer',
 };
 
 /**
@@ -58,6 +81,15 @@ export function domainEndpoints(bind: MailcowClient): DomainEndpoints {
     },
     edit(payload: DomainEditRequest): Promise<MailcowResponse> {
       return bind.requestFactory.post<MailcowResponse, DomainEditRequest>(DOMAIN_ENDPOINTS.EDIT, payload);
+    },
+    deleteTag(domain: string, payload: DomainTagDeleteRequest): Promise<MailcowResponse> {
+      return bind.requestFactory.post<MailcowResponse, DomainTagDeleteRequest>(
+        DOMAIN_ENDPOINTS.DELETE_TAG + `/${domain}`,
+        payload,
+      );
+    },
+    editFooter(payload: DomainFooterEditRequest): Promise<MailcowResponse> {
+      return bind.requestFactory.post<MailcowResponse, DomainFooterEditRequest>(DOMAIN_ENDPOINTS.EDIT_FOOTER, payload);
     },
   };
 }

--- a/src/endpoints/mailbox-endpoint.ts
+++ b/src/endpoints/mailbox-endpoint.ts
@@ -1,13 +1,16 @@
 import {
   ACLEditRequest,
+  MailboxCustomAttributeEditRequest,
   MailboxDeleteRequest,
   MailboxEditRequest,
   MailboxPostRequest,
+  MailboxTagDeleteRequest,
   Mailbox,
   MailcowResponse,
   PushoverEditRequest,
   QuarantineEditRequest,
   SpamScoreEditRequest,
+  SpamScoreGetResponse,
 } from '../types';
 import MailcowClient from '../index';
 import { wrapPromiseToArray } from '../request-factory';
@@ -70,18 +73,48 @@ export interface MailboxEndpoints {
    * @param mailbox - The mailbox to get.
    */
   getActiveUserSieve(mailbox: string): Promise<string[]>;
+
+  /**
+   * Endpoint for removing one or more tags from a mailbox.
+   * @param mailbox - The mailbox to remove tags from.
+   * @param payload - The tags to remove.
+   */
+  deleteTag(mailbox: string, payload: MailboxTagDeleteRequest): Promise<MailcowResponse>;
+
+  /**
+   * Endpoint for writing custom attributes on one or more mailboxes.
+   * @param payload - The edit payload.
+   */
+  editCustomAttribute(payload: MailboxCustomAttributeEditRequest): Promise<MailcowResponse>;
+
+  /**
+   * Endpoint for reading a mailbox's spam score override.
+   * @param mailbox - The mailbox to get the score for, or omit/empty for
+   * the global score (admin only).
+   */
+  getSpamScore(mailbox?: string): Promise<SpamScoreGetResponse>;
+
+  /**
+   * Endpoint for listing all mailboxes belonging to a specific domain.
+   * @param domain - The domain to filter mailboxes by.
+   */
+  getByDomain(domain: string): Promise<Mailbox[]>;
 }
 
 const MAILBOX_ENDPOINTS = {
   CREATE: 'add/mailbox',
   DELETE: 'delete/mailbox',
+  DELETE_TAG: 'delete/mailbox/tag',
   EDIT: 'edit/mailbox',
   GET: 'get/mailbox',
   EDIT_PUSHOVER: 'edit/pushover',
   EDIT_QUARANTINE: 'edit/quarantine_notification',
   EDIT_SPAM_SCORE: 'edit/spam-score',
   EDIT_USER_ACL: 'edit/user-acl',
+  EDIT_CUSTOM_ATTRIBUTE: 'edit/mailbox/custom-attribute',
   GET_ACTIVE_USER_SIEVE: 'get/active-user-sieve',
+  GET_SPAM_SCORE: 'get/spam-score',
+  GET_ALL_BY_DOMAIN: 'get/mailbox/all',
 };
 
 /**
@@ -133,6 +166,30 @@ export function mailboxEndpoints(bind: MailcowClient): MailboxEndpoints {
 
     getActiveUserSieve(mailbox: string): Promise<string[]> {
       return bind.requestFactory.get<string[]>(MAILBOX_ENDPOINTS.GET_ACTIVE_USER_SIEVE + `/${mailbox}`);
+    },
+
+    deleteTag(mailbox: string, payload: MailboxTagDeleteRequest): Promise<MailcowResponse> {
+      return bind.requestFactory.post<MailcowResponse, MailboxTagDeleteRequest>(
+        MAILBOX_ENDPOINTS.DELETE_TAG + `/${mailbox}`,
+        payload,
+      );
+    },
+
+    editCustomAttribute(payload: MailboxCustomAttributeEditRequest): Promise<MailcowResponse> {
+      return bind.requestFactory.post<MailcowResponse, MailboxCustomAttributeEditRequest>(
+        MAILBOX_ENDPOINTS.EDIT_CUSTOM_ATTRIBUTE,
+        payload,
+      );
+    },
+
+    getSpamScore(mailbox: string = ''): Promise<SpamScoreGetResponse> {
+      return bind.requestFactory.get<SpamScoreGetResponse>(MAILBOX_ENDPOINTS.GET_SPAM_SCORE + `/${mailbox}`);
+    },
+
+    getByDomain(domain: string): Promise<Mailbox[]> {
+      return wrapPromiseToArray<Mailbox>(
+        bind.requestFactory.get<Mailbox[] | Mailbox>(MAILBOX_ENDPOINTS.GET_ALL_BY_DOMAIN + `/${domain}`),
+      );
     },
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,6 +236,55 @@ export interface Domain {
 }
 
 /**
+ * Domain tag deletion request.
+ */
+export interface DomainTagDeleteRequest {
+  /**
+   * List of tag names to remove from the domain.
+   */
+  items: string[];
+}
+
+/**
+ * Domain wide footer edit payload.
+ *
+ * Note: the upstream OpenAPI spec documents the exclude list as
+ * `mbox_exclude`, but the PHP handler (`functions.mailbox.inc.php`, case
+ * `domain_wide_footer`) actually reads a single `exclude` field -- a mix
+ * of mailbox addresses and/or alias-domain names -- and sorts each entry
+ * into the internal `mbox_exclude`/`alias_domain_exclude` buckets itself.
+ */
+export interface DomainFooterEditRequest {
+  /**
+   * The footer attributes to set.
+   */
+  attr: {
+    /**
+     * Footer text in HTML format.
+     */
+    html: string;
+    /**
+     * Footer text in plain text format.
+     */
+    plain: string;
+    /**
+     * Mailbox addresses and/or alias-domain names to exclude from the
+     * footer.
+     */
+    exclude?: string[];
+    /**
+     * If true: do not append the footer when replying to a message that
+     * already carries it.
+     */
+    skip_replies?: boolean;
+  };
+  /**
+   * Domains to apply the footer to.
+   */
+  items: string | string[];
+}
+
+/**
  * Antispam policy creation request.
  */
 export interface SpamPolicyPostRequest {

--- a/src/types.ts
+++ b/src/types.ts
@@ -682,6 +682,56 @@ export interface ACLEditRequest {
 }
 
 /**
+ * Mailbox tag deletion request.
+ */
+export interface MailboxTagDeleteRequest {
+  /**
+   * List of tag names to remove from the mailbox.
+   */
+  items: string[];
+}
+
+/**
+ * Mailbox custom attribute edit payload. `attribute` and `value` are
+ * parallel arrays -- `attribute[i]` is combined with `value[i]` into a
+ * single attribute map server-side (`functions.mailbox.inc.php`, case
+ * `mailbox_custom_attribute`).
+ */
+export interface MailboxCustomAttributeEditRequest {
+  /**
+   * The custom attributes to set.
+   */
+  attr: {
+    /**
+     * Attribute keys, parallel to `value`.
+     */
+    attribute: string[];
+    /**
+     * Attribute values, parallel to `attribute`.
+     */
+    value: string[];
+  };
+  /**
+   * Mailboxes to edit.
+   */
+  items: string | string[];
+}
+
+/**
+ * Response of the `get/spam-score/{mailbox}` endpoint.
+ *
+ * Note: the upstream OpenAPI spec documents this key as `spam_score`, but
+ * the PHP handler (`json_api.php`, case `spam-score` under the `get`
+ * action) wraps the value as `score`.
+ */
+export interface SpamScoreGetResponse {
+  /**
+   * The spam score, of the form 'lowerbound,upperbound'.
+   */
+  score: string;
+}
+
+/**
  * Base attributes of an Alias.
  */
 export interface AliasAttributes {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2951,6 +2951,38 @@ export interface IdentityProviderEditRequest {
 }
 
 /**
+ * HTTP methods the Mailcow API's CORS handling will allow.
+ * `functions.inc.php`'s `cors('edit', ...)` validates `allowed_methods`
+ * against exactly these four -- there is no PATCH or OPTIONS.
+ */
+export type CorsAllowedMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+/**
+ * API-wide CORS attributes.
+ */
+export interface CorsAttributes {
+  /**
+   * Origins allowed to make cross-origin requests to the API. Use `'*'`
+   * to allow any origin.
+   */
+  allowed_origins?: string[];
+  /**
+   * HTTP methods allowed for cross-origin requests.
+   */
+  allowed_methods?: CorsAllowedMethod[];
+}
+
+/**
+ * Wire-level body of the `edit/cors` request. The wrapper builds this
+ * for you from {@link CorsAttributes}; unlike most edit requests there is
+ * no `items` envelope -- CORS is a single global setting, not a
+ * per-object one.
+ */
+export interface CorsEditRequest {
+  attr: CorsAttributes;
+}
+
+/**
  * Interface for a general Mailcow API response.
  *
  * This is used when the API call doesn't return any objects, i.e. POST requests.

--- a/src/types.ts
+++ b/src/types.ts
@@ -2546,6 +2546,51 @@ export interface DomainAdmin {
 }
 
 /**
+ * List of possible Domain Admin ACL flags. Sourced from the `da_acl`
+ * table schema (`init_db.inc.php`), which currently includes
+ * `mailbox_relayhost` and `domain_relayhost` -- two flags missing from
+ * the upstream OpenAPI spec's `da_acl` example list.
+ */
+type daAcl =
+  | 'syncjobs'
+  | 'quarantine'
+  | 'login_as'
+  | 'sogo_access'
+  | 'app_passwds'
+  | 'bcc_maps'
+  | 'pushover'
+  | 'filters'
+  | 'ratelimit'
+  | 'spam_policy'
+  | 'extend_sender_acl'
+  | 'unlimited_quota'
+  | 'protocol_access'
+  | 'smtp_ip_access'
+  | 'alias_domains'
+  | 'mailbox_relayhost'
+  | 'domain_relayhost'
+  | 'domain_desc';
+
+/**
+ * Domain Admin ACL edit payload.
+ */
+export interface DaAclEditRequest {
+  /**
+   * Domain admin usernames to edit.
+   */
+  items: string | string[];
+  /**
+   * Attributes to set.
+   */
+  attr: {
+    /**
+     * List of ACLs to set.
+     */
+    da_acl: daAcl[];
+  };
+}
+
+/**
  * Request payload to create a Sender-Dependent Transport (Relayhost).
  */
 export interface CreateRelayhostRequest {

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -364,6 +364,40 @@ describe('Endpoints (smoke against mocked axios)', () => {
     });
   });
 
+  describe('domains.deleteTag', () => {
+    it('posts to delete/domain/tag/{domain} with the items payload', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['domain_modified', 'example.test'] }]);
+      try {
+        await mcc.domains.deleteTag('example.test', { items: ['tag1', 'tag2'] });
+        expect(captured.url).to.equal('https://example.test/api/v1/delete/domain/tag/example.test');
+        expect(captured.payload).to.deep.equal({ items: ['tag1', 'tag2'] });
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('domains.editFooter', () => {
+    it('posts to edit/domain/footer with the attr + items payload', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['domain_footer_modified', 'example.test'] }]);
+      try {
+        await mcc.domains.editFooter({
+          attr: { html: '<br>foo', plain: 'foo', exclude: ['moo@example.test'] },
+          items: 'example.test',
+        });
+        expect(captured.url).to.equal('https://example.test/api/v1/edit/domain/footer');
+        expect(captured.payload).to.deep.equal({
+          attr: { html: '<br>foo', plain: 'foo', exclude: ['moo@example.test'] },
+          items: 'example.test',
+        });
+      } finally {
+        restore();
+      }
+    });
+  });
+
   describe('mailbox.deleteTag', () => {
     it('posts to delete/mailbox/tag/{mailbox} with the items payload', async () => {
       const captured: Captured = {};

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -363,4 +363,80 @@ describe('Endpoints (smoke against mocked axios)', () => {
       }
     });
   });
+
+  describe('mailbox.deleteTag', () => {
+    it('posts to delete/mailbox/tag/{mailbox} with the items payload', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [
+        { type: 'success', msg: ['mailbox_modified', 'foo@example.test'] },
+      ]);
+      try {
+        await mcc.mailbox.deleteTag('foo@example.test', { items: ['tag1', 'tag2'] });
+        expect(captured.url).to.equal('https://example.test/api/v1/delete/mailbox/tag/foo@example.test');
+        expect(captured.payload).to.deep.equal({ items: ['tag1', 'tag2'] });
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('mailbox.editCustomAttribute', () => {
+    it('posts to edit/mailbox/custom-attribute with parallel attribute/value arrays', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['mailbox_modified', 'moo@example.test'] }]);
+      try {
+        await mcc.mailbox.editCustomAttribute({
+          attr: { attribute: ['role', 'foo'], value: ['cow', 'bar'] },
+          items: ['moo@example.test'],
+        });
+        expect(captured.url).to.equal('https://example.test/api/v1/edit/mailbox/custom-attribute');
+        expect(captured.payload).to.deep.equal({
+          attr: { attribute: ['role', 'foo'], value: ['cow', 'bar'] },
+          items: ['moo@example.test'],
+        });
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('mailbox.getSpamScore', () => {
+    it('hits get/spam-score/{mailbox} and returns the score', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, { score: '8,15' });
+      try {
+        const res = await mcc.mailbox.getSpamScore('foo@example.test');
+        expect(captured.url).to.equal('https://example.test/api/v1/get/spam-score/foo@example.test');
+        expect(res).to.deep.equal({ score: '8,15' });
+      } finally {
+        restore();
+      }
+    });
+
+    it('hits get/spam-score/ (trailing slash) for the global score when no mailbox is given', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, { score: '5,15' });
+      try {
+        await mcc.mailbox.getSpamScore();
+        expect(captured.url).to.equal('https://example.test/api/v1/get/spam-score/');
+      } finally {
+        restore();
+      }
+    });
+  });
+
+  describe('mailbox.getByDomain', () => {
+    it('hits get/mailbox/all/{domain} and wraps a single object into an array', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, { username: 'one@example.test' });
+      try {
+        const res = await mcc.mailbox.getByDomain('example.test');
+        expect(captured.url).to.equal('https://example.test/api/v1/get/mailbox/all/example.test');
+        expect(res).to.have.length(1);
+        expect(res[0]).to.deep.include({ username: 'one@example.test' });
+      } finally {
+        restore();
+      }
+    });
+  });
 });

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -364,6 +364,26 @@ describe('Endpoints (smoke against mocked axios)', () => {
     });
   });
 
+  describe('domainAdmins.editACL', () => {
+    it('posts to edit/da-acl with the items + da_acl payload', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: ['acl_saved', 'testadmin'] }]);
+      try {
+        await mcc.domainAdmins.editACL({
+          items: 'testadmin',
+          attr: { da_acl: ['syncjobs', 'quarantine', 'mailbox_relayhost'] },
+        });
+        expect(captured.url).to.equal('https://example.test/api/v1/edit/da-acl');
+        expect(captured.payload).to.deep.equal({
+          items: 'testadmin',
+          attr: { da_acl: ['syncjobs', 'quarantine', 'mailbox_relayhost'] },
+        });
+      } finally {
+        restore();
+      }
+    });
+  });
+
   describe('domains.deleteTag', () => {
     it('posts to delete/domain/tag/{domain} with the items payload', async () => {
       const captured: Captured = {};

--- a/test/endpoints.test.ts
+++ b/test/endpoints.test.ts
@@ -364,6 +364,28 @@ describe('Endpoints (smoke against mocked axios)', () => {
     });
   });
 
+  describe('cors.edit', () => {
+    it('posts to edit/cors with only the attr envelope (no items)', async () => {
+      const captured: Captured = {};
+      const restore = withMockedAxios(captured, [{ type: 'success', msg: 'cors_headers_edited' }]);
+      try {
+        await mcc.cors.edit({
+          allowed_origins: ['*', 'https://mail.example.test'],
+          allowed_methods: ['GET', 'POST', 'PUT', 'DELETE'],
+        });
+        expect(captured.url).to.equal('https://example.test/api/v1/edit/cors');
+        expect(captured.payload).to.deep.equal({
+          attr: {
+            allowed_origins: ['*', 'https://mail.example.test'],
+            allowed_methods: ['GET', 'POST', 'PUT', 'DELETE'],
+          },
+        });
+      } finally {
+        restore();
+      }
+    });
+  });
+
   describe('domainAdmins.editACL', () => {
     it('posts to edit/da-acl with the items + da_acl payload', async () => {
       const captured: Captured = {};


### PR DESCRIPTION
This implements the 8 endpoints listed in #49, the sweep of low-priority gaps between the OpenAPI spec and what the wrapper covers.

| Route | Landed in |
|---|---|
| `edit/cors` | `src/endpoints/cors-endpoints.ts` (new file), `cors.edit` |
| `edit/da-acl` | `src/endpoints/domain-admin-endpoints.ts`, `domainAdmins.editACL` |
| `delete/domain/tag/{domain}` | `src/endpoints/domain-endpoints.ts`, `domains.deleteTag` |
| `delete/mailbox/tag/{mailbox}` | `src/endpoints/mailbox-endpoint.ts`, `mailbox.deleteTag` |
| `edit/domain/footer` | `src/endpoints/domain-endpoints.ts`, `domains.editFooter` |
| `edit/mailbox/custom-attribute` | `src/endpoints/mailbox-endpoint.ts`, `mailbox.editCustomAttribute` |
| `get/spam-score/{mailbox}` | `src/endpoints/mailbox-endpoint.ts`, `mailbox.getSpamScore` |
| `get/mailbox/all/{domain}` | `src/endpoints/mailbox-endpoint.ts`, `mailbox.getByDomain` |

Per the issue, I checked each shape against the current mailcow-dockerized PHP source rather than trusting the spec excerpts alone. Worth noting: the router has moved from `api.php` to `data/web/json_api.php`. Our vendored `reference/openapi.yaml` turned out to be byte-identical to the live upstream spec, so what follows isn't a vendoring-lag problem -- the spec itself has drifted from the PHP in a few places:

`get/spam-score/{mailbox}`: the spec's example response is `{spam_score: "8,15"}`, but the key `json_api.php` actually returns is `score`. `SpamScoreGetResponse` uses `score`.

`edit/domain/footer`: the spec calls the exclude list `mbox_exclude`, but `functions.mailbox.inc.php` (case `domain_wide_footer`) reads a single `exclude` field -- mailbox addresses and alias-domain names mixed together -- and splits it into `mbox_exclude`/`alias_domain_exclude` itself. `DomainFooterEditRequest` uses `exclude`.

`edit/da-acl`: the spec's example only lists 16 `da_acl` flags. The real table schema (`init_db.inc.php`) has 18, including `mailbox_relayhost` and `domain_relayhost`, which I added to the `DaAclEditRequest` union.

`edit/mailbox/custom-attribute`: this one turned out fine as specced. The parallel `attribute`/`value` arrays the issue flagged as worth double-checking really are parallel arrays, combined via `array_combine` in `functions.mailbox.inc.php`.

`edit/cors`: `functions.inc.php`'s `cors()` function only accepts `GET`/`POST`/`PUT`/`DELETE` for `allowed_methods`, so `CorsAllowedMethod` is typed as that union rather than a bare `string[]`.

Each route has a test in `test/endpoints.test.ts` written before the corresponding method existed. `yarn lint`, `yarn format`, `yarn build`, and `yarn test` all pass (35 passing, 70 pending -- the gated live smoke suite, untouched by this change).

Version bumped 1.7.0 -> 1.8.0 with a matching CHANGELOG.md entry.

Closes #49.
